### PR TITLE
fix(`src/poem.txt`): fix character casing of poem title

### DIFF
--- a/src/poem.txt
+++ b/src/poem.txt
@@ -1,5 +1,5 @@
 A Psalm of Life
-By HENRY WADSWORTH LONGFELLOW
+By Henry Wadsworth Longfellow
 
 What The Heart of The Young Man Said To The Psalmist
 

--- a/src/poem.txt
+++ b/src/poem.txt
@@ -1,4 +1,4 @@
-a pSALM oF lIFE
+A Psalm of Life
 By HENRY WADSWORTH LONGFELLOW
 
 What The Heart of The Young Man Said To The Psalmist

--- a/src/poem.txt
+++ b/src/poem.txt
@@ -1,7 +1,7 @@
 A Psalm of Life
 By Henry Wadsworth Longfellow
 
-What The Heart of The Young Man Said To The Psalmist
+"What The Heart of The Young Man Said To The Psalmist"
 
 Tell me not, in mournful numbers,
 Life is but an empty dream!


### PR DESCRIPTION
This PR addresses the casing errors and typos contained in the title header, which comes before the actual content of the poem  itself in `src/poem.txt`.